### PR TITLE
Add decorators to the library.

### DIFF
--- a/changes/2.feature.md
+++ b/changes/2.feature.md
@@ -1,0 +1,1 @@
+Added decorators to the library.

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,0 +1,1 @@
+::: wraps_core.errors

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Early:
           - Decorators: "reference/early/decorators.md"
           - Errors: "reference/early/errors.md"
+      - Errors: "reference/errors.md"
   - Internals: "internals.md"
   - Changelog: "changelog.md"
   - Security: "security.md"

--- a/src/wraps_core/__init__.py
+++ b/src/wraps_core/__init__.py
@@ -18,9 +18,35 @@ from wraps_core.early import (
 )
 from wraps_core.either import Either, Left, Right, is_left, is_right
 from wraps_core.markers import UNREACHABLE, unreachable
-from wraps_core.option import NULL, Null, Option, Some, is_null, is_some, wrap_optional
+from wraps_core.option import (
+    NULL,
+    Null,
+    Option,
+    Some,
+    WrapOption,
+    WrapOptionAwait,
+    is_null,
+    is_some,
+    wrap_option,
+    wrap_option_await,
+    wrap_option_await_on,
+    wrap_option_on,
+    wrap_optional,
+)
 from wraps_core.panics import PANIC, Panic, panic
-from wraps_core.result import Error, Ok, Result, is_error, is_ok
+from wraps_core.result import (
+    Error,
+    Ok,
+    Result,
+    WrapResult,
+    WrapResultAwait,
+    is_error,
+    is_ok,
+    wrap_result,
+    wrap_result_await,
+    wrap_result_await_on,
+    wrap_result_on,
+)
 
 __all__ = (
     # option
@@ -30,13 +56,28 @@ __all__ = (
     "NULL",
     "is_some",
     "is_null",
+    # optional
     "wrap_optional",
+    # option decorators
+    "WrapOption",
+    "WrapOptionAwait",
+    "wrap_option_on",
+    "wrap_option_await_on",
+    "wrap_option",
+    "wrap_option_await",
     # result
     "Result",
     "Ok",
     "Error",
     "is_ok",
     "is_error",
+    # result decorators
+    "WrapResult",
+    "WrapResultAwait",
+    "wrap_result_on",
+    "wrap_result_await_on",
+    "wrap_result",
+    "wrap_result_await",
     # either
     "Either",
     "Left",

--- a/src/wraps_core/errors.py
+++ b/src/wraps_core/errors.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Generic, Type, TypeVar, final
+
+from attrs import Attribute, field, frozen
+from typing_aliases import AnyError, DynamicTuple, EmptyTuple
+from typing_extensions import Self, TypeIs
+
+from wraps_core.panics import panic
+
+__all__ = ("RawErrorTypes", "ErrorTypes")
+
+T = TypeVar("T")
+
+
+def is_empty_tuple(dynamic_tuple: DynamicTuple[T]) -> TypeIs[EmptyTuple]:
+    return not dynamic_tuple
+
+
+E = TypeVar("E", bound=AnyError)
+
+RawErrorTypes = DynamicTuple[Type[E]]
+"""Represents error types. `E` is bound to [`AnyError`][typing_aliases.AnyError]."""
+
+EXPECTED_ERROR_TYPES = "`ErrorTypes[E]` expected non-empty `RawErrorTypes[E]`, got `{}`"
+expected_error_types = EXPECTED_ERROR_TYPES.format
+
+
+@final
+@frozen()
+class ErrorTypes(Generic[E]):
+    """Represents non-empty error types. `E` is bound to [`AnyError`][typing_aliases.AnyError]."""
+
+    raw: RawErrorTypes[E] = field()
+    """Raw error types."""
+
+    @raw.validator
+    def check_raw(self, attribute: Attribute[RawErrorTypes[E]], value: RawErrorTypes[E]) -> None:
+        if is_empty_tuple(value):
+            panic(expected_error_types(value))
+
+    @classmethod
+    def from_head_and_tail(cls, head: Type[E], *tail: Type[E]) -> Self:
+        raw = (head, *tail)
+
+        return cls(raw)
+
+    def extract(self) -> RawErrorTypes[E]:
+        return self.raw


### PR DESCRIPTION
After some considerations, I figured out that it makes sense to include decorators like `wrap_option` and `wrap_result` into the library.